### PR TITLE
Tidier display on RTL pages

### DIFF
--- a/perfmap.js
+++ b/perfmap.js
@@ -88,6 +88,7 @@ function placeMarker(xy, width, height, entry, body, url) {
     marker.className = "perfmap";
     marker.setAttribute("data-ms", parseInt(entry.responseEnd));
     marker.setAttribute("data-body", body);
+    marker.setAttribute("dir", "ltr"); // Force LTR display even if injected on an RTL page
     marker.style.cssText = "position:absolute; transition: 0.5s ease-in-out; box-sizing: border-box; color: #fff; padding-left:10px; padding-right:10px; line-height:14px; font-size: " + size + "px; font-weight:800; font-family:\"Helvetica Neue\",sans-serif; text-align:" + align + "; opacity: " + opacity + "; " + heatmap(heat) + " top: " + xy.top + "px; left: " + xy.left + "px; width: " + width + "px; height:" + height + "px; padding-top:" + paddingTop + "px; z-index: 4000;";
     if(width > 50){
         if(height > 15 ){


### PR DESCRIPTION
This isn't as good as actually translating perfmap into other languages but it avoids the injected text being displayed oddly if injected on an RTL page.

Previously the parentheses wouldn't be displayed symmetrically since they're weakly directional characters and will follow the adjacent text which inherits the overall page direction:

![screen shot 2014-10-21 at 11 13 56 am](https://cloud.githubusercontent.com/assets/46565/4721236/55aec088-5937-11e4-9e74-5d44a5dce915.png)

With this change, they're at least consistent:

![screenshot 2014-10-21 11 31 22](https://cloud.githubusercontent.com/assets/46565/4721261/87ed6d9c-5937-11e4-98ea-ba61b7b8db87.png)
